### PR TITLE
Compatibility with Ruby 1.8

### DIFF
--- a/lib/puppet/provider/cumulus_license/cumulus.rb
+++ b/lib/puppet/provider/cumulus_license/cumulus.rb
@@ -2,14 +2,14 @@ Puppet::Type.type(:cumulus_license).provide :cumulus do
   # If cl_license is missing or not configured as an exec
   # Puppet returns error:
   # "Could not find a suitable provider for cumulus_license"
-  commands cl_license: '/usr/cumulus/bin/cl-license'
+  commands :cl_license => '/usr/cumulus/bin/cl-license'
 
   # If operating system is not cumulus
   # Puppet returns error:
   # "Could not find a suitable provider for cumulus_license"
   # someone asked for a way to log why provider is not suitable
   # but unable to find progress on it. http://bit.ly/17Dhny6
-  confine operatingsystem: [:cumuluslinux]
+  confine :operatingsystem => [:cumuluslinux]
 
   def exists?
     # if license is forced to be installed, install it.

--- a/spec/unit/provider/cumulus_license/base_spec.rb
+++ b/spec/unit/provider/cumulus_license/base_spec.rb
@@ -9,8 +9,8 @@ describe provider_class do
     @src_url = 'http://192.168.10.1/switch.lic'
     @title = 'license'
     @resource = provider_resource.new(
-      src: @src_url,
-      name: @title
+      :src => @src_url,
+      :name => @title
     )
     @provider = provider_class.new(@resource)
   end
@@ -36,9 +36,9 @@ describe provider_class do
     describe 'when resource[:force] is true' do
       before do
         @resource2 = provider_resource.new(
-          src: @src_url,
-          name: @title,
-          force: true
+          :src => @src_url,
+          :name => @title,
+          :force => true
         )
         @provider2 = provider_class.new(@resource2)
       end


### PR DESCRIPTION
When Puppet master is running on an old installation running Ruby 1.8 (Ubuntu Precise, CentOS 6), this module doesn't work because of the new-style hash (introduced in Ruby 1.9). This PR reverts to old-style hash to brings back Ruby 1.8 compatibility.

Most Puppet modules seem to stick to Ruby 1.8 compatibility (first time I got this problem). However, feel free to just close the PR if you are not interested. People needing it will likely find it.